### PR TITLE
v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ You can also use `--devices` or `-d` to specify the GPUs to use.
 knock-on-gpus -d 0,1 -- python my_script.py
 ```
 
+### Auto selection
+
+You can use `--auto-select` to automatically allocate the number of GPUs.
+
+```bash
+knock-on-gpus --auto-select 2 -- python my_script.py
+```
+
+If GPU:0, GPU:1, and GPU:3 are unavailable, `knock-on-gpus` will use GPU:2 and GPU:4.
+
 ### Set alias for `python`
 
 You can set an alias for `python` to use `knock-on-gpus` by default.
@@ -74,3 +84,7 @@ Specifies the environment variable key to set visible devices.
 ### `--verbose`
 
 If true, print verbose logs.
+
+### `--auto-select`
+
+ If a number is given, it will automatically allocate the number of GPUs.

--- a/README.md
+++ b/README.md
@@ -89,4 +89,6 @@ If true, print verbose logs.
 
 ### `--auto-select`
 
- If a number is given, it will automatically allocate the number of GPUs.
+(Alias: `-a`, `--auto`)
+
+If a number is given, it will automatically allocate the number of GPUs.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ Specifies the number of max GPUs to use.
 ### `--cuda-visible-devices-env-key`
 
 Specifies the environment variable key to set visible devices.
+
+### `--verbose`
+
+If true, print verbose logs.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Then you can run your script without `knock-on-gpus`.
 
 ## Options
 
-### `--devices` (short: `-d`)
+### `--devices`
+
+(Alias: `-d`, `--device`)
 
 Specifies the GPUs to use. The value is a comma-separated list of GPU IDs.
 

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -1,5 +1,6 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use itertools::Itertools;
+use log::debug;
 use nvml_wrapper::Nvml;
 
 #[derive(Debug, Clone)]
@@ -9,18 +10,42 @@ pub struct GPUStatus {
     pub used_memory: u64,
     pub gpu_utilization: u32,
     pub memory_utilization: u32,
+    pub is_vacant: bool,
 }
 
 #[derive(Debug, Clone)]
-pub enum GPUAvailability {
-    Vacant(Vec<GPUStatus>),
-    Occupied(Vec<GPUStatus>),
+pub enum GPUAvailability<T> {
+    Vacant(T),
+    Occupied(T),
 }
 
-pub fn get_gpu_availability(devices: &Vec<u32>, memory_border_mib: f32) -> Result<GPUAvailability> {
+fn validate_num_requested(num_requested: usize, devices: &Vec<u32>) -> Result<()> {
+    if num_requested > devices.len() {
+        bail!(
+            concat!(
+                "The number of requested GPUs is greater than the number of visible devices.\n",
+                "Visible devices: {}\n",
+                "The number of GPUs you requested: {}"
+            ),
+            devices.len(),
+            num_requested
+        );
+    }
+    Ok(())
+}
+
+pub fn get_gpu_availability(
+    devices: &Vec<u32>,
+    memory_border_mib: f32,
+    num_requested: Option<usize>,
+) -> Result<GPUAvailability<Vec<GPUStatus>>> {
     let nvml = Nvml::init()?;
     let memory_border_mib = memory_border_mib;
     let memory_border_bytes = (memory_border_mib * 1024.0 * 1024.0) as u64;
+
+    if let Some(n) = num_requested {
+        validate_num_requested(n, devices)?;
+    }
 
     let status = devices
         .iter()
@@ -30,23 +55,35 @@ pub fn get_gpu_availability(devices: &Vec<u32>, memory_border_mib: f32) -> Resul
         })
         .map_ok(|device| {
             let utilization = device.utilization_rates()?;
+            let used_memory = device.memory_info()?.used;
             Ok(GPUStatus {
                 id: device.index()?,
-                used_memory: device.memory_info()?.used,
+                used_memory,
                 gpu_utilization: utilization.gpu,
                 memory_utilization: utilization.memory,
+                is_vacant: used_memory < memory_border_bytes,
             })
         })
         .flatten()
         .collect::<Result<Vec<GPUStatus>>>()?;
 
-    let is_vacant = status.iter().any(|s| {
-        s.used_memory < memory_border_bytes && s.gpu_utilization < 20 && s.memory_utilization < 20
-    });
+    debug!("GPU status:\n{:#?}", status);
 
-    if is_vacant {
-        Ok(GPUAvailability::Vacant(status))
+    if let Some(n) = num_requested {
+        let fullfilled = status.iter().filter(|s| s.is_vacant).count() >= n;
+        if fullfilled {
+            let status = status.into_iter().filter(|s| s.is_vacant).take(n).collect();
+            debug!("Selected:\n{:#?}", status);
+            Ok(GPUAvailability::Vacant(status))
+        } else {
+            Ok(GPUAvailability::Occupied(status))
+        }
     } else {
-        Ok(GPUAvailability::Occupied(status))
+        let is_all_vacant: bool = status.iter().all(|s| s.is_vacant);
+        if is_all_vacant {
+            Ok(GPUAvailability::Vacant(status))
+        } else {
+            Ok(GPUAvailability::Occupied(status))
+        }
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,9 +3,18 @@ use env_logger;
 use std::env;
 use std::io::Write;
 
-pub(crate) fn init_logger() {
+pub(crate) fn init_logger(default_level: log::Level) {
     if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "info");
+        env::set_var(
+            "RUST_LOG",
+            match default_level {
+                log::Level::Error => "error",
+                log::Level::Warn => "warn",
+                log::Level::Info => "info",
+                log::Level::Debug => "debug",
+                log::Level::Trace => "trace",
+            },
+        );
     }
     env_logger::Builder::from_default_env()
         .format(|buf, record| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,10 @@ mod logger;
 use availability::{get_gpu_availability, GPUAvailability};
 use clap::Parser;
 use colored::Colorize;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use std::process::ExitCode;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Visible devices
@@ -57,6 +57,8 @@ fn main() -> ExitCode {
     } else {
         log::Level::Info
     });
+
+    debug!("Arguments: {:#?}", args);
 
     let is_cuda_available = devices::is_cuda_available();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ struct Args {
     max_gpus: usize,
 
     /// If a number is given, it will automatically allocate the number of GPUs.
-    #[arg(long)]
+    #[arg(short, long, alias = "auto")]
     auto_select: Option<usize>,
 
     /// If true, print debug logs

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::process::ExitCode;
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Visible devices
-    #[arg(short, long)]
+    #[arg(short, long, alias = "device")]
     devices: Option<String>,
 
     /// Commands to execute after checking GPU availability.

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,14 +37,22 @@ struct Args {
     #[arg(long, default_value = "1024")] // 1024 is a big enough number
     max_gpus: usize,
 
+    /// If true, print debug logs
+    #[arg(long)]
+    verbose: bool,
+
     /// Environment variable key to set visible devices
     #[arg(long, default_value = "CUDA_VISIBLE_DEVICES")]
     cuda_visible_devices_env_key: String,
 }
 
 fn main() -> ExitCode {
-    logger::init_logger();
     let args = Args::parse();
+    logger::init_logger(if args.verbose {
+        log::Level::Debug
+    } else {
+        log::Level::Info
+    });
 
     let is_cuda_available = devices::is_cuda_available();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,10 @@ struct Args {
     #[arg(long, default_value = "1024")] // 1024 is a big enough number
     max_gpus: usize,
 
+    /// If a number is given, it will automatically allocate the number of GPUs.
+    #[arg(long)]
+    auto_select: Option<usize>,
+
     /// If true, print debug logs
     #[arg(long)]
     verbose: bool,
@@ -100,19 +104,20 @@ fn main() -> ExitCode {
     let devices = devices;
 
     // Check if selected devices are available
-    let availability = if devices.len() == 0 {
-        Ok(GPUAvailability::Vacant(vec![]))
-    } else {
-        get_gpu_availability(&devices, args.memory_border_mib)
-    };
+    let availability =
+        get_gpu_availability(&devices, args.memory_border_mib, args.auto_select.clone());
 
     match availability {
-        Ok(GPUAvailability::Vacant(_)) => {
+        Ok(GPUAvailability::Vacant(devices)) => {
             let devices_str = devices
                 .iter()
-                .map(|x| x.to_string())
+                .map(|x| x.id.to_string())
                 .collect::<Vec<String>>()
                 .join(",");
+
+            if args.auto_select.as_ref().is_some() {
+                info!("{} GPU(s) will be used.", devices.len());
+            }
 
             // Print the message
             if devices.len() == 0 {
@@ -138,8 +143,11 @@ fn main() -> ExitCode {
                 status.wait().expect("Failed to wait for command");
             } else {
                 warn!(
-                    "No command to execute.\n\
-                If you use this command with `&&`, use `--` instead.\n{}",
+                    concat!(
+                        "No command to execute.\n",
+                        "If you use this command with `&&`, use `--` instead.\n",
+                        "{}"
+                    ),
                     "Example: `knock-on-gpus --devices 0,1 -- python train.py`".dimmed()
                 );
             }
@@ -147,9 +155,21 @@ fn main() -> ExitCode {
         }
 
         Ok(GPUAvailability::Occupied(status)) => {
+            let devices_you_want = devices
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<Vec<String>>()
+                .join(",");
+            let used_devices = status
+                .iter()
+                .filter(|s| !s.is_vacant)
+                .map(|s| s.id.to_string())
+                .collect::<Vec<String>>();
             error!(
-                "GPU(s) are currently in use\n{:?}\nSee `nvidia-smi` for more information.",
-                status
+                "You tried to use GPU {}, but GPU {} {} currently in use.\nSee `nvidia-smi` for more information.",
+                &devices_you_want,
+                &used_devices.join(","),
+                if used_devices.len() > 1 { "are" } else { "is" }
             );
             ExitCode::FAILURE
         }


### PR DESCRIPTION
- Add `--auto-select` option
  - This will automatically select the specified number of GPUs, avoiding GPUs that are in use
  - Alias: `-a`, `--auto`
- Add alias `--device` for `--devices`
- Add `--verbose` option
  - This prints debug logs.