### PR TITLE
Disallow omitting extra commands by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "knock-on-gpus"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "knock-on-gpus"
 authors = ["TrpFrog"]
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ knock-on-gpus -- python my_script.py
 
 If some GPUs are not available, `knock-on-gpus` will return an error code and print a message to the console.
 
+> [!NOTE]
+> **`knock-on-gpus` prohibits omitting the extra command** (`python my_script.py` in this example) **by default**.
+> This is to avoid accidentally executing the subsequent command without passing `CUDA_VISIBLE_DEVICES`.
+>
+> Please see [`--allow-noop` option](#--allow-noop) for details.
+
+
 ### Using with `CUDA_VISIBLE_DEVICES`
 
 You can also use `knock-on-gpus` to run a script with specific GPUs.
@@ -92,3 +99,33 @@ If true, print verbose logs.
 (Alias: `-a`, `--auto`)
 
 If a number is given, it will automatically allocate the number of GPUs.
+
+### `--allow-noop`
+
+If true, allow running without executing extra commands.
+
+#### Examples
+
+```sh
+$ knock-on-gpus -d "0,1,2,3" -- sh -c 'echo "devices=$CUDA_VISIBLE_DEVICES"'
+# => devices=0,1,2,3
+```
+
+If GPUs are available, this will succeed. *"devices=0,1,2,3"* will be printed.
+
+```sh
+$ knock-on-gpus && sh -c 'echo "devices=$CUDA_VISIBLE_DEVICES"'
+# => ERROR: Omitting the command is not allowed.
+```
+
+Even if GPUs are available, this will fail because no command passed to `knock-on-gpus`.
+
+Note that `&&` has no effect to pass the command to `knock-on-gpus`.
+
+```sh
+$ knock-on-gpus --allow-noop && sh -c 'echo "devices=$CUDA_VISIBLE_DEVICES"'
+# => devices=
+```
+
+If GPUs are available, this will succeed.
+**BUT** *"devices="* is printed instead of *"devices=0,1,2,3"* because `sh -c ...` is not passed to `knock-on-gpus`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "knock-on-gpus"
-version = "0.0.2"
+version = "0.1.0"
 readme = "README.md"
 license = {file = "LICENSE"}
 description = "A CLI tool for checking if GPUs are available before running your script that uses GPUs."

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ struct Args {
     memory_border_mib: f32,
 
     /// If true, use GPU strictly. If CUDA is not available, it will fail.
-    #[arg(long, default_value = "false")]
+    #[arg(long)]
     use_gpu_strictly: bool,
 
     /// Number of min GPUs to use
@@ -44,6 +44,9 @@ struct Args {
     /// If true, print debug logs
     #[arg(long)]
     verbose: bool,
+
+    #[arg(long)]
+    allow_noop: bool,
 
     /// Environment variable key to set visible devices
     #[arg(long, default_value = "CUDA_VISIBLE_DEVICES")]
@@ -152,6 +155,13 @@ fn main() -> ExitCode {
                     ),
                     "Example: `knock-on-gpus --devices 0,1 -- python train.py`".dimmed()
                 );
+                if !args.allow_noop {
+                    error!(concat!(
+                        "Omitting the command is not allowed.\n",
+                        "Use `--allow-noop` to allow omitting the command."
+                    ));
+                    return ExitCode::FAILURE;
+                }
             }
             ExitCode::SUCCESS
         }


### PR DESCRIPTION
- **Explicit Command Requirement by Default**: By default, `knock-on-gpus` now requires an explicit command to be passed after specifying GPU devices. This change was made to prevent accidental execution of subsequent commands without the correct `CUDA_VISIBLE_DEVICES` environment variable being set. The explicit command requirement ensures that users are aware of the command being executed in the context of available GPUs, enhancing the tool's usability and safety.

- **No-Operation Mode Support (`--allow-noop`)**: We've added the `--allow-noop` flag to allow `knock-on-gpus` to be run without specifying a subsequent command. This enhancement addresses the need for flexibility in scenarios where users may want to initiate `knock-on-gpus` without immediately executing a follow-up task. This can be particularly useful in workflows or scripts where the objective is to prepare or validate the GPU environment prior to deciding on the execution of further commands. The `--allow-noop` option prevents the tool from raising an error when no command is provided, offering a smoother experience in such cases.